### PR TITLE
Add the ability to bind callback on success/error (requestPager)

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -269,7 +269,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 		},
 
 		goTo: function ( page, arg ) {
-			if(page !== undefined && typeof page !== object){
+			if(page !== undefined && typeof page !== 'object'){
 				this.page = parseInt(page, 10);
 				return this.pager(arg);				
 			}


### PR DESCRIPTION
Add the ability to bind callback on success/error when calling requestNextPage or requestPreviousPage (wich is by default supported by Backbone .fetch() method).

The argument to pass is a hash containing a success and/or error functions.

I tried to keep code style but it's sometime inconsistent; so let me know if anything is wrong or if you'd like any changes.

Regards

(BTW: I haven't find any folder containing existing unit testing so I didn't add test for this change...)
