### PR TITLE
In some cases, functions as values won't work as expected.

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -60,17 +60,15 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 				type: 'GET',
 				dataType: 'jsonp'
 			});
-			
-			// URL value could be function, let's make sure to run it if so
-			queryOptions.url = _.result(queryOptions, 'url');
-			
+
 			queryOptions = _.extend(queryOptions, {
 				jsonpCallback: 'callback',
 				data: decodeURIComponent($.param(queryAttributes)),
-				processData: false
-			});
+				processData: false,
+				url: _.result(queryOptions, 'url')
+			}, options);
 			
-			return $.ajax( _.extend(queryOptions, options) );
+			return $.ajax( queryOptions );
 
 		},
 
@@ -433,17 +431,15 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 				type: 'GET',
 				dataType: 'jsonp'
 			});
-			
-			// URL value could be function, let's make sure to run it if so
-			queryOptions.url = _.result(queryOptions, 'url');
-			
+
 			queryOptions = _.extend(queryOptions, {
 				jsonpCallback: 'callback',
 				data: decodeURIComponent($.param(queryAttributes)),
-				processData: false
-			});
+				processData: false,
+				url: _.result(queryOptions, 'url')
+			}, options);
 			
-			return $.ajax( _.extend(queryOptions, options) );
+			return $.ajax( queryOptions );
 
 		},
 


### PR DESCRIPTION
Configuration was cloned but the cloned object wasn't used, making functions as values not working.
Means, the functions was run once, but then the returned value was kept, instead of the function itself. 
