### PR TITLE
Fix : RequestPager Example Sorting Issue 

### DIFF
--- a/examples/netflix-request-paging/collections/PaginatedCollection.js
+++ b/examples/netflix-request-paging/collections/PaginatedCollection.js
@@ -64,7 +64,12 @@
 			'$skip': function() { return this.currentPage * this.perPage },
 			
 			// field to sort by
-			'$orderby': 'ReleaseYear',
+			'$orderby': function() {
+				if(this.sortField === undefined)
+					return 'ReleaseYear';
+				return this.sortField;
+			},
+
 			
 			// what format would you like to request results in?
 			'$format': 'json',


### PR DESCRIPTION
The demo at [Backbone.Paginator.requestPager()](http://addyosmani.github.com/backbone.paginator/examples/netflix-request-paging/index.html) does nothing on 'Sort By' . 

[issue page](https://github.com/addyosmani/backbone.paginator/issues/33)
