### PR TITLE
info() returns correct previous attribute

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -552,7 +552,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 			};
 
 			if (self.currentPage > 1) {
-				info.prev = self.currentPage - 1;
+				info.previous = self.currentPage - 1;
 			}
 
 			if (self.currentPage < info.totalPages) {


### PR DESCRIPTION
I believe this was a mistake since the `info` object that gets returned is originally initialized with a `previous` attribute, not `prev`. This caused me some confusion when I was working on a pagination view.
