### PR TITLE
queryAttributes at request time

### DIFF
--- a/dist/backbone.paginator.js
+++ b/dist/backbone.paginator.js
@@ -678,6 +678,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 				dataType: 'jsonp'
 			});
 
+			// Allows the passing in of {data: {foo: 'bar'}} at request time to overwrite server_api defaults
 			if( options.data ){
 				options.data = decodeURIComponent($.param(_.extend(queryAttributes,options.data)));
 			}else{

--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -675,9 +675,15 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 				dataType: 'jsonp'
 			});
 
+			// Allows the passing in of {data: {foo: 'bar'}} at request time to overwrite server_api defaults
+			if( options.data ){
+				options.data = decodeURIComponent($.param(_.extend(queryAttributes,options.data)));
+			}else{
+				options.data = decodeURIComponent($.param(queryAttributes));
+			}
+
 			queryOptions = _.extend(queryOptions, {
 				jsonpCallback: 'callback',
-				data: decodeURIComponent($.param(queryAttributes)),
 				processData: false,
 				url: _.result(queryOptions, 'url')
 			}, options);


### PR DESCRIPTION
I wanted to be able to overwrite the defaults and the model defaults (server_api). So, I allow the user to pass in data parameters in the fetch request.

Example: 

Documents.fetch({
      data: {per: 5, page: 5},
      success: ....
})
