### PR TITLE
lighter/faster doFakeFieldFilter() and doFakeFilter()

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -170,26 +170,24 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 
 		// doFakeFieldFilter can be used to get the number of models that will remain
 		// after calling setFieldFilter with a filter rule(s)
-		doFakeFieldFilter: function ( fieldFilterRules ) {
-			if( !_.isEmpty( fieldFilterRules ) ) {
-				var bkp_lastFieldFilterRules = this.lastFieldFilterRules;
-				var bkp_fieldFilterRules = this.fieldFilterRules;
+		doFakeFieldFilter: function ( rules ) {
+			if( !_.isEmpty( rules ) ) {
+				var testModels = this.origModels;
+				if (testModels === undefined) {
+					testModels = this.models;
+				}
 
-				this.lastFieldFilterRules = this.fieldFilterRules;
-				this.fieldFilterRules = fieldFilterRules;
-				this.pager();
-				this.info();
+				testModels = this._fieldFilter(testModels, rules);
 
-				var cmodels = this.models.length;
-
-				this.lastFieldFilterRules = bkp_lastFieldFilterRules;
-				this.fieldFilterRules = bkp_fieldFilterRules;
-				this.pager();
-				this.info();
+				// To comply with current behavior, also filter by any previously defined setFilter rules.
+				if ( this.filterExpression !== "" ) {
+					testModels = this._filter(testModels, this.filterFields, this.filterExpression);
+				}
 
 				// Return size
-				return cmodels;
+				return testModels.length;
 			}
+      
 		},
     
 		// setFilter is used to filter the current model. After
@@ -214,26 +212,20 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 		// remain after calling setFilter with a `fields` and `filter` args. 
 		doFakeFilter: function ( fields, filter ) {
 			if( fields !== undefined && filter !== undefined ){
-				var bkp_filterFields = this.filterFields;
-				var bkp_lastFilterExpression = this.lastFilterExpression;
-				var bkp_filterExpression = this.filterExpression;
+				var testModels = this.origModels;
+				if (testModels === undefined) {
+					testModels = this.models;
+				}
 
-				this.filterFields = fields;
-				this.lastFilterExpression = this.filterExpression;
-				this.filterExpression = filter;
-				this.pager();
-				this.info();
+				// To comply with current behavior, first filter by any previously defined setFieldFilter rules.
+				if ( !_.isEmpty( this.fieldFilterRules ) ) {
+					testModels = this._fieldFilter(testModels, this.fieldFilterRules);
+				}
 
-				var cmodels = this.models.length;
-
-				this.filterFields = bkp_filterFields;
-				this.lastFilterExpression = bkp_lastFilterExpression;
-				this.filterExpression = bkp_filterExpression;
-				this.pager();
-				this.info();
+				testModels = this._filter(testModels, fields, filter);
 
 				// Return size
-				return cmodels;
+				return testModels.length;
 			}
 		},
 


### PR DESCRIPTION
Rewrite of doFakeFieldFilter() and doFakeFilter() to improve efficiency. The original approach involved some heavy DOM changes, etc. The approach I'm using here is simply do the calculations and return the result - no DOM changes needed/wanted.

Hope you find this useful, either way, many thanks for making paginator available - the netflix demo sites have been immensely helpful.
-Reed
