### PR TITLE
Removed no-op sort from requestPager to prevent headaches.

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -816,10 +816,6 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 			}
 		},
 
-		sort: function () {
-			//assign to as needed.
-		},
-
 		info: function () {
 
 			var info = {


### PR DESCRIPTION
Backbone.Collection by default comes with a sort method that works when a comparator is defined. This undocumented no-op sort() method nullified that behavior and could cause surprises for code that assume the sort() method in Collection subclasses to work.
