### PR TITLE
Allow 'server_api' to be a function that returns an object

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -75,7 +75,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       // Some values could be functions, let's make sure
       // to change their scope too and run them
       var queryAttributes = {};
-      _.each(self.server_api, function(value, key){
+      _.each(_.result(self, "server_api"), function(value, key){
         if( _.isFunction(value) ) {
           value = _.bind(value, self);
           value = value();
@@ -732,7 +732,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       // Some values could be functions, let's make sure
       // to change their scope too and run them
       var queryAttributes = {};
-      _.each(self.server_api, function(value, key){
+      _.each(_.result(self, "server_api"), function(value, key){
         if( _.isFunction(value) ) {
           value = _.bind(value, self);
           value = value();

--- a/test/backbone.paginator.requestPager_test.js
+++ b/test/backbone.paginator.requestPager_test.js
@@ -194,6 +194,26 @@ describe('backbone.paginator.requestPager',function(){
       expect(spy.lastCall.args[0]['data']).to.equal('pageZeroBased=1&searchTerm=Obama&sortBy=lastName');
     });
 
+    it ("should take the result of 'server_api' if it is a callable", function(){
+      var requestPagerTest = {
+        paginator_ui: {},
+        paginator_core: {},
+        server_api: function () {
+          return {
+            pageZeroBased: 1,
+            searchTerm: function () { return 'Obama'; },
+            sortBy: 'lastName'
+          };
+        }
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+
+      var options = {};
+      requestPagerTest.sync(null, null, options);
+
+      expect(spy.lastCall.args[0]['data']).to.equal('pageZeroBased=1&searchTerm=Obama&sortBy=lastName');
+    });
+
     it("should evaluate value as function (if it is) before setting 'data' query param for the ajax call from 'server_api'", function(){
       var requestPagerTest = {
         paginator_ui : {},


### PR DESCRIPTION
I have run into cases where I would like to be able to compute 'server_api' on the fly, such as omitting or adding fields.  I could maybe accomplish this with the current behavior of allowing functions as values
in the mapping, but I think it would add more complexity (e.g., I would have to include all fields, and any that I want to omit would have to have callable values that return undefined, and I'm not even sure if that would work).

This pull request adds this simple change, along with a test.
