### PR TITLE
Really make the package.json source of version information

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -13,8 +13,7 @@ module.exports = function(grunt) {
     concat: {
       dist: {
         src: ['<banner>', '<file_strip_banner:lib/<%= pkg.name %>.js>'],
-        dest: 'dist/<%= pkg.name %>.js',
-        process: true
+        dest: 'dist/<%= pkg.name %>.js'
       }
     },
     min: {
@@ -61,9 +60,17 @@ module.exports = function(grunt) {
   });
 
   // Default task.
-  grunt.registerTask('default', 'lint mocha concat min');
+  grunt.registerTask('default', 'lint mocha concat replace-version min');
   grunt.registerTask('test', 'lint mocha');
 
   // run `npm install grunt-mocha` in project root dir and uncomment this
   grunt.loadNpmTasks('grunt-mocha');
+
+  grunt.registerTask('replace-version', 'replace the version placeholder in backbone.paginator.js', function() {
+    var pkg = grunt.config.get('pkg');
+    var filename = 'dist/' + pkg.name + '.js';
+    var content = grunt.file.read(filename);
+    var rendered = grunt.template.process(content, { pkg : pkg });
+    grunt.file.write(filename, rendered);
+  });
 };


### PR DESCRIPTION
Sadly, the `concat` task throws an error when asked to do the processing, so I've written an inline task to replace the placeholder in the source file instead.
