### PR TITLE
Bump version, REAME fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 0.next
+## 0.5.1-dev
 
-* ---
+* Propagate version number from `package.json` to codebase during build
 
 ## 0.5
 
@@ -17,7 +17,7 @@
 * Make the API cleaner
 * Some bug fixes
 
-## 0.15 
+## 0.15
 
 * Rewrite to simplify the project API
 * Unify components under the same collection hood

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backbone.Paginator (0.5)
+# Backbone.Paginator (0.5.1-dev)
 
 [![Continuous Integration status](https://secure.travis-ci.org/addyosmani/backbone.paginator.png)](http://travis-ci.org/addyosmani/backbone.paginator)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone.paginator",
   "description": "A set of pagination components for Backbone.js",
-  "version": "0.5.0",
+  "version": "0.5.1-dev",
   "homepage": "http://github.com/addyosmani/backbone.paginator",
   "author": {
     "name": "Addy Osmani",


### PR DESCRIPTION
I've set the version to `0.5.1-dev` which should become `0.5.1` (or `0.6.0`) when released.

I've also taken the liberty to replace the tabs in README with spaces and done other various amendments to the README. Hope that is ok.
