### PR TITLE
Conflict with Backbone 0.9.10

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -100,35 +100,46 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         dataType: 'jsonp'
       });
 
-      var success = options.success;
-      options.success = function ( resp, status, xhr ) {
-        if ( success ) {
-          success( resp, status, xhr );
-        }
-        if ( model && model.trigger ) {
-          model.trigger( 'sync', model, resp, options );
-        }
-      };
-
-      var error = options.error;
-      options.error = function ( xhr, status, thrown ) {
-        if ( error ) {
-          error( model, xhr, options );
-        }
-        if ( model && model.trigger ) {
-          model.trigger( 'error', model, xhr, options );
-        }
-      };
-
       queryOptions = _.extend(queryOptions, {
         data: decodeURIComponent($.param(queryAttributes)),
         processData: false,
         url: _.result(queryOptions, 'url')
       }, options);
 
-      var xhr = $.ajax( queryOptions );
+      var bbVer = Backbone.VERSION.split('.');
+      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
+                              parseInt(bbVer[1], 10) === 9 &&
+                              parseInt(bbVer[2], 10) <= 9);
+
+      var success = queryOptions.success;
+      queryOptions.success = function ( resp, status, xhr ) {
+
+        if ( success ) {
+          // This is to keep compatibility with Backbone older than 0.9.10
+          if (oldSuccessFormat) {
+            success( resp, status, xhr );
+          } else {
+            success( model, resp, queryOptions );
+          }
+        }
+        if ( model && model.trigger ) {
+          model.trigger( 'sync', model, resp, queryOptions );
+        }
+      };
+
+      var error = queryOptions.error;
+      queryOptions.error = function ( xhr ) {
+        if ( error ) {
+          error( model, xhr, queryOptions );
+        }
+        if ( model && model.trigger ) {
+          model.trigger( 'error', model, xhr, queryOptions );
+        }
+      };
+
+      var xhr = queryOptions.xhr = $.ajax( queryOptions );
       if ( model && model.trigger ) {
-        model.trigger('request', model, xhr, options);
+        model.trigger('request', model, xhr, queryOptions);
       }
       return xhr;
     },
@@ -789,34 +800,46 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         options.data = decodeURIComponent($.param(queryAttributes));
       }
 
-      var success = options.success;
-      options.success = function ( resp, status, xhr ) {
-        if ( success ) {
-          success( resp, status, xhr );
-        }
-        if ( model && model.trigger ) {
-          model.trigger( 'sync', model, resp, options );
-        }
-      };
-
-      var error = options.error;
-      options.error = function ( xhr, status, thrown ) {
-        if ( error ) {
-          error( model, xhr, options );
-        }
-        if ( model && model.trigger ) {
-          model.trigger( 'error', model, xhr, options );
-        }
-      };
-
       queryOptions = _.extend(queryOptions, {
+        data: decodeURIComponent($.param(queryAttributes)),
         processData: false,
         url: _.result(queryOptions, 'url')
       }, options);
 
-      var xhr = $.ajax( queryOptions );
+      var bbVer = Backbone.VERSION.split('.');
+      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
+                              parseInt(bbVer[1], 10) === 9 &&
+                              parseInt(bbVer[2], 10) <= 9);
+
+      var success = queryOptions.success;
+      queryOptions.success = function ( resp, status, xhr ) {
+
+        if ( success ) {
+          // This is to keep compatibility with Backbone older than 0.9.10
+          if (oldSuccessFormat) {
+            success( resp, status, xhr );
+          } else {
+            success( model, resp, queryOptions );
+          }
+        }
+        if ( model && model.trigger ) {
+          model.trigger( 'sync', model, resp, queryOptions );
+        }
+      };
+
+      var error = queryOptions.error;
+      queryOptions.error = function ( xhr ) {
+        if ( error ) {
+          error( model, xhr, queryOptions );
+        }
+        if ( model && model.trigger ) {
+          model.trigger( 'error', model, xhr, queryOptions );
+        }
+      };
+
+      var xhr = queryOptions.xhr = $.ajax( queryOptions );
       if ( model && model.trigger ) {
-        model.trigger('request', model, xhr, options);
+        model.trigger('request', model, xhr, queryOptions);
       }
       return xhr;
     },


### PR DESCRIPTION
The newest version of Backbone (0.9.10) changed the arguments passed to "success" callback, which support was added by my last pull request (#107).

I'm sending a fix using the new arguments while keeping compatibility with Backbone 0.9.9 and older.

ref: documentcloud/backbone#2003
