### PR TITLE
Pager interface unification

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -144,22 +144,24 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       return xhr;
     },
 
-    nextPage: function () {
+    nextPage: function (options) {
       if(this.currentPage < this.information.totalPages) {
         this.currentPage = ++this.currentPage;
-        this.pager();
+        this.pager(options);
       }
     },
 
-    previousPage: function () {
-      this.currentPage = --this.currentPage || 1;
-      this.pager();
+    previousPage: function (options) {
+      if(this.currentPage > 1) {
+        this.currentPage = --this.currentPage;
+        this.pager(options);
+      }
     },
 
-    goTo: function ( page ) {
+    goTo: function ( page, options ) {
       if(page !== undefined){
         this.currentPage = parseInt(page, 10);
-        this.pager();
+        this.pager(options);
       }
     },
 
@@ -274,7 +276,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 
     // pager is used to sort, filter and show the data
     // you expect the library to display.
-    pager: function () {
+    pager: function (options) {
       var self = this,
       disp = this.perPage,
       start = (self.currentPage - 1) * disp,
@@ -319,6 +321,13 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       self.sortedAndFilteredModels = self.models;
 
       self.reset(self.models.slice(start, stop));
+
+      // This is somewhat of a hack to get all the nextPage, prevPage, and goTo methods
+      // to work with a success callback (as in the requestPager). Realistically there is no failure case here,
+      // but maybe we could catch exception and trigger a failure callback?
+      if (!_.isUndefined(options) && !_.isUndefined(options['success'])) {
+        options['success']();
+      }
     },
 
     // The actual place where the collection is sorted.
@@ -740,6 +749,8 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
 
   });
 
+  // function aliasing
+  Paginator.clientPager.prototype.prevPage = Paginator.clientPager.prototype.previousPage;
 
   // @name: requestPager
   //
@@ -922,17 +933,21 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         totalPages: Math.ceil(this.totalRecords / this.perPage),
         lastPage: this.totalPages, // should use totalPages in template
         perPage: this.perPage,
-        hasPrevious:false,
-        hasNext:false
+        previous:false,
+        next:false
       };
 
       if (this.currentPage > 1) {
-        info.hasPrevious = this.currentPage - 1;
+        info.previous = this.currentPage - 1;
       }
 
       if (this.currentPage < info.totalPages) {
-        info.hasNext = this.currentPage + 1;
+        info.next = this.currentPage + 1;
       }
+
+      // left around for backwards compatibility
+      info.hasNext = info.next;
+      info.hasPrevious = info.next;
 
       info.pageSet = this.setPagination(info);
 
@@ -1013,6 +1028,10 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       return this;
     }
   });
+
+  // function aliasing
+  Paginator.requestPager.prototype.nextPage = Paginator.requestPager.prototype.requestNextPage;
+  Paginator.requestPager.prototype.prevPage = Paginator.requestPager.prototype.requestPreviousPage;
 
   return Paginator;
 

--- a/test/backbone.paginator.clientPager_test.js
+++ b/test/backbone.paginator.clientPager_test.js
@@ -384,39 +384,53 @@ describe('backbone.paginator.clientPager', function() {
   });
 
   describe("nextPage", function(){
-
-    it('should increment "currentPage" by 1 and call pager', function() {
-      var pagerSpy = sinon.stub(this.clientPagerTest, 'pager');
+    var pagerSpy;
+    beforeEach(function() {
+      pagerSpy = sinon.stub(this.clientPagerTest, 'pager');
       this.clientPagerTest.information = {totalPages : 99};
+    });
+    afterEach(function() {
+      pagerSpy.restore();
+    });
+    it('should increment "currentPage" by 1 and call pager', function() {
       this.clientPagerTest.currentPage = 9;
 
       this.clientPagerTest.nextPage();
 
       expect(this.clientPagerTest.currentPage).to.equal(10);
       expect(pagerSpy.calledOnce).to.equal(true);
-
-      pagerSpy.restore();
     });
     it('should not increment "currentPage"', function() {
-      var pagerSpy = sinon.stub(this.clientPagerTest, 'pager');
-      this.clientPagerTest.information = {totalPages : 99};
       this.clientPagerTest.currentPage = 99;
 
       this.clientPagerTest.nextPage();
 
       expect(this.clientPagerTest.currentPage).to.equal(99);
       expect(pagerSpy.calledOnce).to.equal(false);
+    });
+    it('should accept an options param and pass it to the pager method', function() {
+      this.clientPagerTest.currentPage = 9;
 
-      pagerSpy.restore();
+      var options = {success: function() {}};
+      this.clientPagerTest.nextPage(options);
+      expect(pagerSpy.lastCall.args[0]).to.equal(options);
     });
   });
   describe('previousPage', function() {
+    var pagerSpy;
+    beforeEach(function() {
+      pagerSpy = sinon.stub(this.clientPagerTest, 'pager');
+    });
+    afterEach(function() {
+      pagerSpy.restore();
+    });
     it('should decrement "currentPage" by 1 and call pager', function() {
       this.clientPagerTest.currentPage = 9;
 
       this.clientPagerTest.previousPage();
 
       expect(this.clientPagerTest.currentPage).to.equal(8);
+      expect(pagerSpy.calledOnce).to.equal(true);
     });
     it('should not decrement the page when currentPage is 1', function() {
       this.clientPagerTest.currentPage = 1;
@@ -424,6 +438,14 @@ describe('backbone.paginator.clientPager', function() {
       this.clientPagerTest.previousPage();
 
       expect(this.clientPagerTest.currentPage).to.equal(1);
+      expect(pagerSpy.calledOnce).to.equal(false);
+    });
+    it('should accept an options param and pass it to the pager method', function() {
+      this.clientPagerTest.currentPage = 2;
+
+      var options = {success: function() {}};
+      this.clientPagerTest.previousPage(options);
+      expect(pagerSpy.lastCall.args[0]).to.equal(options);
     });
   });
   describe('goTo', function() {
@@ -449,6 +471,12 @@ describe('backbone.paginator.clientPager', function() {
       pagerSpy.restore();
     });
   });
+  describe('prevPage', function() {
+    it('should be an alias for the previousPage function', function() {
+      expect(this.clientPagerTest.prevPage).to.equal(this.clientPagerTest.previousPage);
+    });
+  });
+
   describe('howManyPer', function() {
     it('should set perPage, currentPage and call pager method', function() {
       var pagerSpy = sinon.stub(this.clientPagerTest, 'pager');
@@ -471,7 +499,7 @@ describe('backbone.paginator.clientPager', function() {
       pagerSpy.restore();
     });
   });
-  describe('bootstrap method', function() {
+  describe('bootstrap', function() {
     beforeEach(function() {
       this.defaultsStub.restore();
       var OPTS = {
@@ -502,6 +530,18 @@ describe('backbone.paginator.clientPager', function() {
     });
     it('should return an instance of this', function() {
       expect(this.clientPagerTest.bootstrap()).to.equal(this.clientPagerTest);
+    });
+  });
+  describe('pager', function() {
+    // TODO: write many more tests for this function
+    it('should accept an options param and call a success callback', function() {
+      var successCallbackSpy = sinon.spy();
+      this.clientPagerTest.pager({success: successCallbackSpy});
+      expect(successCallbackSpy.calledOnce).to.equal(true);
+    });
+    it('should not try to invoke an undefined success callback', function() {
+      expect(this.clientPagerTest.pager()).to.be.undefined;
+      expect(this.clientPagerTest.pager({error: function() {}})).to.undefined;
     });
   });
 

--- a/test/backbone.paginator.requestPager_test.js
+++ b/test/backbone.paginator.requestPager_test.js
@@ -439,6 +439,13 @@ describe('backbone.paginator.requestPager',function(){
     });
   });
 
+  describe("nextPage", function() {
+    it("should alias the requestNextPage function", function() {
+      var requestPagerTest = new Backbone.Paginator.requestPager();
+      expect(requestPagerTest.nextPage).to.equal(requestPagerTest.requestNextPage);
+    });
+  });
+
   describe("requestPreviousPage", function(){
 
     it("should decrement 'currentPage' by 1 and call pager method", function(){
@@ -460,6 +467,13 @@ describe('backbone.paginator.requestPager',function(){
       expect(spy.calledOnce).to.equal(true);
 
       spy.restore();
+    });
+  });
+
+  describe("prevPage", function() {
+    it("should alias the requestPreviousPage function", function() {
+      var requestPagerTest = new Backbone.Paginator.requestPager();
+      expect(requestPagerTest.prevPage).to.equal(requestPagerTest.requestPreviousPage);
     });
   });
 


### PR DESCRIPTION
#### This pull request is regarding the following issue:

https://github.com/addyosmani/backbone.paginator/issues/125
#### The (verbose) comment for this commit is as follows:

'Unified' the interfaces of some common public methods between clientPager and requestPager: nextPage(options), prevPage(options), goToPage(pageNum, options). In Paginator.requestPager, simply aliased the 'requestNextPage' and 'requestPreviousPage' functions to 'nextPage' and 'prevPage' respectively. In Paginator.clientPager modified 'pager' function to accept 'options' param and trigger a 'success' function defined in the options. Unified the variable names from 'previous', 'next' (clientPage) and 'hasPrevious' , 'hasNext' (requestPager) information object to 'previous', 'next'.
### Additional Details:

This change unifies the interfaces between clientPager and requestPager to the extent that the same Backbone view can use them interchangeably. This change does not make (or hinder, afaik) any progress towards Backbone 1.0 compatibility. Some functions in the client and request pagers were aliased to maintain backwards compatibility with the Backbone.Paginator library.

Probably the biggest 'hack' here is at the end of the clientPager.pager function. 

Lines 328-330 of backbone.paginator.js

``` javascript
if (!_.isUndefined(options) && !_.isUndefined(options['success'])) {
  options['success']();
}
```

I did this because I haven't yet had the chance to dig into the implication of getting this options passed down and evaluated by the Backbone.Collection.reset method. If someone has a clear path on a better way to handle this particular piece of code please let me know.

That said, I also couldn't come up with any realistic failure scenarios for clientPager failure. On the requestPager, the options get passed into the Backbone.Collection.fetch function and the 'error' callback will be invoked when a non-200 series response gets returned from the server. For the clientPager, I could have added some exception handling(?) and invoke the error method when an exception is caught. However it may not be terribly important to support an error callback for clientPager functions that invoke '.pager' function. Also, the success method on the clientPager will be invoked with empty args, as opposed the response arguments, etc., passed in by Backbone in the requestPager (which is really another interface disparity, but it still brings us closer).

I ended up aliasing the 'hasPrevious' and 'hasNext'  properties of the 'information' object in the requestPager to 'previous' and 'next'. I know that these properties aren't really considered to be public, but they were convenient to use in my view to determine pagination boundaries. Perhaps we can consider making some formal public methods '.next' and '.previous' live off of the collection itself.

I also refactored some various test cases in the suite.

Please let me know if there's anything that I can change and/or clean up. Thanks!
