### PR TITLE
Remove empty sort function.

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -914,10 +914,6 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       }
     },
 
-    sort: function () {
-      //assign to as needed.
-    },
-
     info: function () {
 
       var info = {


### PR DESCRIPTION
By removing the function it allows Backbone's standard Collection.sort() functionality to continue to work.

See #139
