### PR TITLE
Add links to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 0.5.1-dev
 
-* Propagate version number from `package.json` to codebase during build
-* Transparently support both backbone 9.9 and 9.10 style `success` callback
-  arguments
-* Allow bootstrapping of pager data without server interaction
+* [Propagate version number from `package.json` to codebase during build](https://github.com/addyosmani/backbone.paginator/commit/5f7d2ff0a8f7e6f87e5a6e2081dc029c3fd0e70c)
+* [Transparently support both backbone 9.9 and 9.10 style `success` callback arguments](https://github.com/addyosmani/backbone.paginator/commit/c6c37ea6392c9427d67487e1316592a4a0475e92)
+* [Unify interfaces of requestPager and clientPager](https://github.com/addyosmani/backbone.paginator/commit/d4135188c6c956999116157fb9c51e9779e78d57)
+* [Allow bootstrapping of pager data without server interaction](https://github.com/addyosmani/backbone.paginator/commit/babb81d7f5245a52053a008a2b82bbbcd324cd4a)
 * Bug fixes
 
 ## 0.5


### PR DESCRIPTION
How about doing a release in the near future?

Maybe we should go through the issue tracker and mark issues a blockers for the next version. (I'm suggesting `0.6`).
