### PR TITLE
Fix sync success arguments on Backbone 1.0.0

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -107,15 +107,15 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       }, options);
 
       var bbVer = Backbone.VERSION.split('.');
-      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
-                              parseInt(bbVer[1], 10) === 9 &&
-                              parseInt(bbVer[2], 10) <= 9);
+      var promiseSuccessFormat = !(parseInt(bbVer[0], 10) === 0 &&
+                                   parseInt(bbVer[1], 10) === 9 &&
+                                   parseInt(bbVer[2], 10) === 10);
 
       var success = queryOptions.success;
       queryOptions.success = function ( resp, status, xhr ) {
         if ( success ) {
-          // This is to keep compatibility with Backbone older than 0.9.10
-          if (oldSuccessFormat) {
+          // This is to keep compatibility with Backbone 0.9.10
+          if (promiseSuccessFormat) {
             success( resp, status, xhr );
           } else {
             success( model, resp, queryOptions );
@@ -820,16 +820,16 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       }, options);
 
       var bbVer = Backbone.VERSION.split('.');
-      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
-                              parseInt(bbVer[1], 10) === 9 &&
-                              parseInt(bbVer[2], 10) <= 9);
+      var promiseSuccessFormat = !(parseInt(bbVer[0], 10) === 0 &&
+                                   parseInt(bbVer[1], 10) === 9 &&
+                                   parseInt(bbVer[2], 10) === 10);
 
       var success = queryOptions.success;
       queryOptions.success = function ( resp, status, xhr ) {
 
         if ( success ) {
-          // This is to keep compatibility with Backbone older than 0.9.10
-          if (oldSuccessFormat) {
+          // This is to keep compatibility with Backbone 0.9.10
+          if (promiseSuccessFormat) {
             success( resp, status, xhr );
           } else {
             success( model, resp, queryOptions );

--- a/test/backbone.paginator.clientPager_test.js
+++ b/test/backbone.paginator.clientPager_test.js
@@ -253,7 +253,7 @@ describe('backbone.paginator.clientPager', function() {
 
 
     it('should use the correct "options.success" arguments', function(done){
-      // This is to keep compatibility with Backbone older than 0.9.10
+      // This is to keep compatibility with Backbone 0.9.10
       var clientPagerTest = {
         paginator_ui: {},
         paginator_core: {
@@ -268,9 +268,9 @@ describe('backbone.paginator.clientPager', function() {
       server.respondWith([200, { "Content-Type": "application/json" }, '{ "key": "value" }']);
 
       var bbVer = Backbone.VERSION.split('.');
-      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
-                              parseInt(bbVer[1], 10) === 9 &&
-                              parseInt(bbVer[2], 10) <= 9);
+      var promiseSuccessFormat = !(parseInt(bbVer[0], 10) === 0 &&
+                                   parseInt(bbVer[1], 10) === 9 &&
+                                   parseInt(bbVer[2], 10) === 10);
 
       var model = {};
 
@@ -278,7 +278,7 @@ describe('backbone.paginator.clientPager', function() {
         success: function(model_, resp_, options) {
           // verify
           var bbVer = Backbone.VERSION.split('.');
-          if (oldSuccessFormat) {
+          if (promiseSuccessFormat) {
             var status_ = resp_;
             resp_ = model_;
             var xhr_ = options;

--- a/test/backbone.paginator.requestPager_test.js
+++ b/test/backbone.paginator.requestPager_test.js
@@ -157,7 +157,7 @@ describe('backbone.paginator.requestPager',function(){
     });
 
     it('should use the correct "options.success" arguments', function(done){
-      // This is to keep compatibility with Backbone older than 0.9.10
+      // This is to keep compatibility with Backbone 0.9.10
       var requestPagerTest = {
         paginator_ui: {},
         paginator_core: {
@@ -172,9 +172,9 @@ describe('backbone.paginator.requestPager',function(){
       server.respondWith([200, { "Content-Type": "application/json" }, '{ "key": "value" }']);
 
       var bbVer = Backbone.VERSION.split('.');
-      var oldSuccessFormat = (parseInt(bbVer[0], 10) === 0 &&
-                              parseInt(bbVer[1], 10) === 9 &&
-                              parseInt(bbVer[2], 10) <= 9);
+      var promiseSuccessFormat = !(parseInt(bbVer[0], 10) === 0 &&
+                                   parseInt(bbVer[1], 10) === 9 &&
+                                   parseInt(bbVer[2], 10) === 10);
 
       var model = {};
 
@@ -182,7 +182,7 @@ describe('backbone.paginator.requestPager',function(){
         success: function(model_, resp_, options) {
           // verify
           var bbVer = Backbone.VERSION.split('.');
-          if (oldSuccessFormat) {
+          if (promiseSuccessFormat) {
             var status_ = resp_;
             resp_ = model_;
             var xhr_ = options;


### PR DESCRIPTION
On Backbone 1.0.0 the arguments to the `success` callback of the `sync` method were changed again to be compatible with jQuery-style promises. [Here's the relevant Backbone commit](https://github.com/documentcloud/backbone/commit/6e646f1ba71dd889226a8f99f4d3e7e4ed2b706e).

The `sync` method in both Paginator.clientPager and Paginator.requestPager contain a version check which doesn't yet take into account this change. I've changed the version check to only target Backbone 0.9.10 which had a different format for the callback.

All tests pass with Backbone 0.9.9 ("promise-style"), 0.9.10 ("model-style") and 1.0.0 ("promise-style").
