### PR TITLE
Replaced $.ajax with Backbone.ajax

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -140,7 +140,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         }
       };
 
-      var xhr = queryOptions.xhr = $.ajax( queryOptions );
+      var xhr = queryOptions.xhr = Backbone.ajax( queryOptions );
       if ( model && model.trigger ) {
         model.trigger('request', model, xhr, queryOptions);
       }
@@ -850,7 +850,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         }
       };
 
-      var xhr = queryOptions.xhr = $.ajax( queryOptions );
+      var xhr = queryOptions.xhr = Backbone.ajax( queryOptions );
       if ( model && model.trigger ) {
         model.trigger('request', model, xhr, queryOptions);
       }


### PR DESCRIPTION
Using $.ajax directly makes it hard to override the ajax method being used.
