### PR TITLE
Add options and return Deferred for requestPager updateOrder and howManyPer

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -762,6 +762,13 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
   // function aliasing
   Paginator.clientPager.prototype.prevPage = Paginator.clientPager.prototype.previousPage;
 
+  // Helper function to generate rejected Deferred
+  var reject = function () {
+    var response = new $.Deferred();
+    response.reject();
+    return response.promise();
+  };
+
   // @name: requestPager
   //
   // Paginator for server-side data being requested from a backend/API
@@ -882,9 +889,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         this.currentPage += 1;
         return this.pager( options );
       } else {
-        var response = new $.Deferred();
-        response.reject();
-        return response.promise();
+        return reject();
       }
     },
 
@@ -893,9 +898,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         this.currentPage -= 1;
         return this.pager( options );
       } else {
-        var response = new $.Deferred();
-        response.reject();
-        return response.promise();
+        return reject();
       }
     },
 
@@ -904,9 +907,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         this.sortField = column;
         return this.pager( options );
       } else {
-        var response = new $.Deferred();
-        response.reject();
-        return response.promise();
+        return reject();
       }
     },
 
@@ -915,9 +916,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         this.currentPage = parseInt(page, 10);
         return this.pager( options );
       } else {
-        var response = new $.Deferred();
-        response.reject();
-        return response.promise();
+        return reject();
       }
     },
 
@@ -927,9 +926,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         this.perPage = count;
         return this.pager( options );
       } else {
-        var response = new $.Deferred();
-        response.reject();
-        return response.promise();
+        return reject();
       }
     },
 

--- a/test/backbone.paginator.requestPager_test.js
+++ b/test/backbone.paginator.requestPager_test.js
@@ -461,6 +461,28 @@ describe('backbone.paginator.requestPager',function(){
 
       spy.restore();
     });
+
+    it("should return a rejected promise if currentPage is undefined", function(done){
+      var requestPagerTest = {
+        paginator_ui: {},
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      requestPagerTest.requestNextPage()
+        .done(function() {
+          // This is always a fail condition, done should never be called.
+          expect().fail("done should not be called");
+          spy.restore();
+          done();
+        })
+        .fail(function() {
+          expect(spy.called).to.equal(false);
+          spy.restore();
+          done();
+        });
+    });
   });
 
   describe("nextPage", function() {
@@ -492,6 +514,28 @@ describe('backbone.paginator.requestPager',function(){
 
       spy.restore();
     });
+
+    it("should return a rejected promise if currentPage is undefined", function(done){
+      var requestPagerTest = {
+        paginator_ui: {},
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      requestPagerTest.requestPreviousPage()
+        .done(function() {
+          // This is always a fail condition, done should never be called.
+          expect().fail("done should not be called");
+          spy.restore();
+          done();
+        })
+        .fail(function() {
+          expect(spy.called).to.equal(false);
+          spy.restore();
+          done();
+        });
+    });
   });
 
   describe("prevPage", function() {
@@ -501,7 +545,56 @@ describe('backbone.paginator.requestPager',function(){
     });
   });
 
-  describe("goto", function(){
+  describe("updateOrder", function(){
+
+    it("should set sortField to the field we want and call pager method", function(){
+      var requestPagerTest = {
+        paginator_ui: {
+          currentPage: 1
+        },
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      var options = {};
+      requestPagerTest.sync(null, null, options);
+      requestPagerTest.updateOrder('column');
+
+      expect(requestPagerTest.sortField).to.equal('column');
+      expect(spy.calledOnce).to.equal(true);
+
+      spy.restore();
+    });
+
+    it("should return a rejected promise if column is undefined", function(done){
+      var requestPagerTest = {
+        paginator_ui: {
+          currentPage: 1
+        },
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      var options = {};
+      requestPagerTest.sync(null, null, options);
+      requestPagerTest.updateOrder()
+        .done(function() {
+          // This is always a fail condition, done should never be called.
+          expect().fail("done should not be called");
+          spy.restore();
+          done();
+        })
+        .fail(function() {
+          expect(spy.called).to.equal(false);
+          spy.restore();
+          done();
+        });
+    });
+  });
+
+  describe("goTo", function(){
 
     it("should set currentPage to the page we want goto and call pager method", function(){
       var requestPagerTest = {
@@ -521,6 +614,32 @@ describe('backbone.paginator.requestPager',function(){
       expect(spy.calledOnce).to.equal(true);
 
       spy.restore();
+    });
+
+    it("should return a rejected promise if page is undefined", function(done){
+      var requestPagerTest = {
+        paginator_ui: {
+          currentPage: 1
+        },
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      var options = {};
+      requestPagerTest.sync(null, null, options);
+      requestPagerTest.goTo()
+        .done(function() {
+          // This is always a fail condition, done should never be called.
+          expect().fail("done should not be called");
+          spy.restore();
+          done();
+        })
+        .fail(function() {
+          expect(spy.called).to.equal(false);
+          spy.restore();
+          done();
+        });
     });
   });
 
@@ -565,6 +684,32 @@ describe('backbone.paginator.requestPager',function(){
       expect(requestPagerTest.currentPage).to.equal(1);
 
       spy.restore();
+    });
+
+    it("should return a rejected promise if count is undefined", function(done){
+      var requestPagerTest = {
+        paginator_ui: {
+          perPage: 5
+        },
+        paginator_core: {}
+      };
+      _.extend(requestPagerTest, new Backbone.Paginator.requestPager());
+      var spy = sinon.spy(requestPagerTest, 'pager');
+
+      var options = {};
+      requestPagerTest.sync(null, null, options);
+      requestPagerTest.howManyPer()
+        .done(function() {
+          // This is always a fail condition, done should never be called.
+          expect().fail("done should not be called");
+          spy.restore();
+          done();
+        })
+        .fail(function() {
+          expect(spy.called).to.equal(false);
+          spy.restore();
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
I've added support for options to requestPager updateOrder and howManyPer methods. This resolves parts of #150 and #153 (which are duplicates).

They also now returned the deferred XHR objects or rejected promises in the same manor as requestNextPage, requestPreviousPage, and goTo. This was addressed in #45 but for some reason it was not added to updateOrder and howManyPer.
