### PR TITLE
Reset

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -72,8 +72,8 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       this.origModels.splice(index, 1);
     },
 
-    resetModel: function(){
-      this.origModels = [];
+    resetModel: function(collection){
+      this.origModels = collection.models;
     },
 
     sync: function ( method, model, options ) {

--- a/test/backbone.paginator.clientPager_test.js
+++ b/test/backbone.paginator.clientPager_test.js
@@ -151,6 +151,10 @@ describe('backbone.paginator.clientPager', function() {
       this.clientPagerTest.reset();
 
       expect(this.clientPagerTest.origModels).to.eql([]);
+
+      this.clientPagerTest.reset([model.toJSON(), model.toJSON()]);
+
+      expect(this.clientPagerTest.origModels).to.have.length(2);
     });
   });
 


### PR DESCRIPTION
This patch will make the paginator's models array match the collection after a reset. This functionality is useful to users who are fetching a collection with the reset option (`collection.fetch({reset: true})`), or are resetting a collection at initialization from the backend.
