### PR TITLE
Fixed Twitter Bootstrap repository urls

### DIFF
--- a/examples/client-paging/collections/PaginatedCollection.js
+++ b/examples/client-paging/collections/PaginatedCollection.js
@@ -12,7 +12,7 @@
 			dataType: 'jsonp',
 		
 			// the URL (or base URL) for the service
-			url: 'https://api.github.com/repos/twitter/bootstrap/issues?'
+			url: 'https://api.github.com/repos/twbs/bootstrap/issues?'
 		},
 		
 		paginator_ui: {

--- a/examples/request-paging/collections/PaginatedCollection.js
+++ b/examples/request-paging/collections/PaginatedCollection.js
@@ -30,7 +30,7 @@
 			dataType: 'jsonp',
 		
 			// the URL (or base URL) for the service
-			url: 'https://api.github.com/repos/twitter/bootstrap/issues?'
+			url: 'https://api.github.com/repos/twbs/bootstrap/issues?'
 		},
 		
 		paginator_ui: {


### PR DESCRIPTION
I fixed Twitter Bootstrap repository urls.

But it still use old urls in https://github.com/backbone-paginator/backbone.paginator#live-examples even for http://backbone-paginator.github.io/backbone.paginator/examples/infinite-paging/index.html, which had been fixed by @jrmlstf few weeks ago. 
