### PR TITLE
Added default collection url processing to requestPager

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -813,7 +813,8 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         timeout: 25000,
         cache: false,
         type: 'GET',
-        dataType: 'jsonp'
+        dataType: 'jsonp',
+        url: self.url
       });
 
       // Allows the passing in of {data: {foo: 'bar'}} at request time to overwrite server_api defaults


### PR DESCRIPTION
This eleminates a need to separately declare an url in paginator_core once collection already have one.
