### PR TITLE
update Bootstrap API urls in examples

### DIFF
--- a/examples/client-paging/collections/PaginatedCollection.js
+++ b/examples/client-paging/collections/PaginatedCollection.js
@@ -12,7 +12,7 @@
 			dataType: 'jsonp',
 		
 			// the URL (or base URL) for the service
-			url: 'https://api.github.com/repos/twitter/bootstrap/issues?'
+			url: 'https://api.github.com/repos/twbs/bootstrap/issues?'
 		},
 		
 		paginator_ui: {

--- a/examples/request-paging/collections/PaginatedCollection.js
+++ b/examples/request-paging/collections/PaginatedCollection.js
@@ -30,7 +30,7 @@
 			dataType: 'jsonp',
 		
 			// the URL (or base URL) for the service
-			url: 'https://api.github.com/repos/twitter/bootstrap/issues?'
+			url: 'https://api.github.com/repos/twbs/bootstrap/issues?'
 		},
 		
 		paginator_ui: {


### PR DESCRIPTION
The previous urls are no longer functional. Updated.
