### PR TITLE
Fix error callback triggered with wrong parameters

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -135,7 +135,7 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
       var error = queryOptions.error;
       queryOptions.error = function ( xhr ) {
         if ( error ) {
-          error( model, xhr, queryOptions );
+          error( xhr );
         }
         if ( isBeforeBackbone_1_0 && model && model.trigger ) {
           model.trigger( 'error', model, xhr, queryOptions );


### PR DESCRIPTION
Backbone.js by default wraps error callback with a wrapError function and expects an xhr object as parameter. This fixes the same by passing xhr to error callback instead of the collection object.
