### PR TITLE
Allow query attributes to be passed as JSON.

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -817,15 +817,19 @@ Backbone.Paginator = (function ( Backbone, _, $ ) {
         url: self.url
       });
 
-      // Allows the passing in of {data: {foo: 'bar'}} at request time to overwrite server_api defaults
-      if( options.data ){
-        options.data = decodeURIComponent($.param(_.extend(queryAttributes,options.data)));
+      // Allows passing query attributes as JSON
+      if( /application\/json/.test(queryOptions.contentType) ) {
+        options.data = JSON.stringify(_.extend(queryAttributes, options.data));
       }else{
-        options.data = decodeURIComponent($.param(queryAttributes));
+        // Allows the passing in of {data: {foo: 'bar'}} at request time to overwrite server_api defaults
+        if( options.data ){
+          options.data = decodeURIComponent($.param(_.extend(queryAttributes,options.data)));
+        }else{
+          options.data = decodeURIComponent($.param(queryAttributes));
+        }
       }
 
       queryOptions = _.extend(queryOptions, {
-        data: decodeURIComponent($.param(queryAttributes)),
         processData: false,
         url: _.result(queryOptions, 'url')
       }, options);


### PR DESCRIPTION
Not sure why it forces attributes to be sent URL-encoded. My use case is complex/nested query objects (in Elasticsearch format) being sent as JSON.
