### PR TITLE
Adding bower.json to specify main script

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,3 @@
 {
-  "name": "backbone.paginator",
-  "homepage": "https://github.com/addyosmani/backbone.paginator",
-  "version": "2.0.3",
   "main": "lib/backbone.paginator.js"
 }


### PR DESCRIPTION
Without the `main` element in `bower.json`, other tools such as `debowerify` have no clue where to find the main source file.
