### PR TITLE
Adding bower.json file and ignoring api and examples directories in bower file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "backbone.paginator",
+  "version": "2.0.2",
+  "homepage": "https://github.com/backbone-paginator/backbone.paginator",
+  "authors": [
+    "Jimmy Yuen Ho Wong <wyuenho@gmail.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "api",
+    "examples"
+  ]
+}


### PR DESCRIPTION
The main motivation is that api/resources/css/app-[*].css references ../images/facebook-16.png which doesn't exist; this causes css optimisers to fail.

When installing this project via bower, we're not really interested in these directories.