### PR TITLE
Enforce data type check in fetch function

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -1146,31 +1146,33 @@
               "directions");
 
       var i, kvp, k, v, kvps = _pairs(queryParams), thisCopy = _clone(this);
-      for (i = 0; i < kvps.length; i++) {
-        kvp = kvps[i], k = kvp[0], v = kvp[1];
-        v = _isFunction(v) ? v.call(thisCopy) : v;
-        if (state[k] != null && v != null) {
-          data[v] = state[k];
-        }
-      }
-
-      // fix up sorting parameters
-      if (state.sortKey && state.order) {
-        var o = _isFunction(queryParams.order) ?
-          queryParams.order.call(thisCopy) :
-          queryParams.order;
-        data[o] = this.queryParams.directions[state.order + ""];
-      }
-      else if (!state.sortKey) delete data[queryParams.order];
-
-      // map extra query parameters
-      var extraKvps = _pairs(_omit(this.queryParams,
-                                   _keys(PageableProto.queryParams)));
-      for (i = 0; i < extraKvps.length; i++) {
-        kvp = extraKvps[i];
-        v = kvp[1];
-        v = _isFunction(v) ? v.call(thisCopy) : v;
-        if (v != null) data[kvp[0]] = v;
+      if (typeof data == "object") {
+	      for (i = 0; i < kvps.length; i++) {
+	        kvp = kvps[i], k = kvp[0], v = kvp[1];
+	        v = _isFunction(v) ? v.call(thisCopy) : v;
+	        if (state[k] != null && v != null) {
+	          data[v] = state[k];
+	        }
+	      }
+	
+	      // fix up sorting parameters
+	      if (state.sortKey && state.order) {
+	        var o = _isFunction(queryParams.order) ?
+	          queryParams.order.call(thisCopy) :
+	          queryParams.order;
+	        data[o] = this.queryParams.directions[state.order + ""];
+	      }
+	      else if (!state.sortKey) delete data[queryParams.order];
+	
+	      // map extra query parameters
+	      var extraKvps = _pairs(_omit(this.queryParams,
+	                                   _keys(PageableProto.queryParams)));
+	      for (i = 0; i < extraKvps.length; i++) {
+	        kvp = extraKvps[i];
+	        v = kvp[1];
+	        v = _isFunction(v) ? v.call(thisCopy) : v;
+	        if (v != null) data[kvp[0]] = v;
+	      }
       }
 
       if (mode != "server") {


### PR DESCRIPTION
I recently use paginator to build my web application. I encountered an issue to use "fetch" function. Specifically, the options.data doesn't allow stringfied JSON data, and it always assume it is an object type. I suggest to check the type of data before we change the attribute inside.

Related issue: https://github.com/backbone-paginator/backbone.paginator/issues/258