### PR TITLE
fix for "Uncaught TypeError: Cannot read property 'add' of undefined" when fetching after switchmode

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -714,7 +714,8 @@
         fullCollection.pageableCollection = this;
         this.fullCollection = fullCollection;
         var allHandler = this._makeCollectionEventHandler(this, fullCollection);
-        _each(["add", "remove", "reset", "sort"], function (event) {
+        if (this.fullCollection.events) {
+          _each(["add", "remove", "reset", "sort"], function (event) {
           handlers[event] = handler = _.bind(allHandler, {}, event);
           self.on(event, handler);
           fullCollection.on(event, handler);


### PR DESCRIPTION
under some circumstances there are no events in  fullCollection and while fetching new page after switchmode it leads to "Uncaught TypeError: Cannot read property 'add' of undefined"
