### PR TITLE
Remove query parameters for totalPages and totalRecords state

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -1174,7 +1174,7 @@
       var queryParams = this.mode == "client" ?
         _pick(this.queryParams, "sortKey", "order") :
         _omit(_pick(this.queryParams, _keys(PageableProto.queryParams)),
-              "directions");
+              "directions", "totalPages", "totalRecords");
 
       var thisCopy = _.clone(this);
       _.each(queryParams, function (v, k) {

--- a/test/infinite-pageable.js
+++ b/test/infinite-pageable.js
@@ -113,9 +113,7 @@ $(document).ready(function () {
     strictEqual(this.ajaxSettings.url, "url");
     deepEqual(this.ajaxSettings.data, {
       page: 2,
-      "per_page": 2,
-      "total_entries": 4,
-      "total_pages": 2
+      "per_page": 2
     });
 
     this.ajaxSettings.success([

--- a/test/server-pageable.js
+++ b/test/server-pageable.js
@@ -295,8 +295,6 @@ $(document).ready(function () {
       page: 0,
       "per_page": 50,
       "sort_by": "name",
-      "total_entries": 50,
-      "total_pages": 1,
       "access_token": 1
     });
 
@@ -324,8 +322,6 @@ $(document).ready(function () {
       "per_page": 50,
       "sort_by": ["firstSort", "secondSort"],
       "order_test": ["asc", "desc"],
-      "total_entries": 50,
-      "total_pages": 1,
       "access_token": 1
     });
 


### PR DESCRIPTION
These changes remove the query parameters for `totalRecords` and `totalPages` keys of `queryParams` which defaults to `total_entries` and `total_pages`. It removes them from the ajax request while fetching the collection as these params have no meaningful information for server and server already knows these things.

Although same can be achieved by setting these queryParams `null` but then they will not be updated after server respond with `total_entries` and `total_pages`.

```javascript
queryParams: {
  totaPages: null,
  totalRecords: null
}
```

@wyuenho please review it.