### PR TITLE
fire pageable:state:change after fetching

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -1039,6 +1039,8 @@
        new code is encouraged to overridePageableCollection#parseState
        andPageableCollection#parseRecords instead.
 
+       @fires PageableCollection#pageable:state:change
+
        @param {Object} resp The deserialized response data from the server.
        @param {Object} the options for the ajax request
 
@@ -1046,7 +1048,10 @@
     */
     parse: function (resp, options) {
       var newState = this.parseState(resp, _clone(this.queryParams), _clone(this.state), options);
-      if (newState) this.state = this._checkState(_extend({}, this.state, newState));
+      if (newState) {
+        this.state = this._checkState(_extend({}, this.state, newState));
+        if (!(options || {}).silent) this.trigger("pageable:state:change", this.state);
+      }
       return this.parseRecords(resp, options);
     },
 

--- a/test/server-pageable.js
+++ b/test/server-pageable.js
@@ -18,6 +18,8 @@ $(document).ready(function () {
                  {"name": "a"},
                  {"name": "a"}]];
     var col = new Backbone.PageableCollection();
+    sinon.spy(col, "trigger");
+
     var models = col.parse(resp);
     deepEqual(models, [{"name": "b"},
                        {"name": "c"},
@@ -29,6 +31,7 @@ $(document).ready(function () {
     strictEqual(col.state.totalRecords, 4);
     strictEqual(col.state.sortKey, "name");
     strictEqual(col.state.order, 1);
+    ok(col.trigger.calledWith("pageable:state:change", col.state));
 
     resp  = [{"name": "a"},
              {"name": "a"},
@@ -46,6 +49,25 @@ $(document).ready(function () {
     strictEqual(col.state.totalRecords, 4);
     strictEqual(col.state.sortKey, "name");
     strictEqual(col.state.order, 1);
+    ok(col.trigger.calledWith("pageable:state:change", col.state));
+
+    resp  = [{total_entries: 6}, [{"name": "a"},
+      {"name": "a"},
+      {"name": "b"},
+      {"name": "c"}]];
+
+    models = col.parse(resp);
+    deepEqual(models, [{"name": "a"},
+      {"name": "a"},
+      {"name": "b"},
+      {"name": "c"}]);
+    strictEqual(col.state.currentPage, 1);
+    strictEqual(col.state.pageSize, 2);
+    strictEqual(col.state.totalPages, 3);
+    strictEqual(col.state.totalRecords, 6);
+    strictEqual(col.state.sortKey, "name");
+    strictEqual(col.state.order, 1);
+    ok(col.trigger.calledWith("pageable:state:change", col.state));
   });
 
   test("_checkState", function () {


### PR DESCRIPTION
The `pageable:state:change` does not fire when only the server state changes. E.g. the total number of entries increases, but the element on the current page do not change. In the case the collection does not need to updated, so no events are fired there and thus no `pageable:state:change` event is fired.

This PR fixes this by firing `pageable:state:change` after the parsing the server state.