### PR TITLE
Fix the example in the demo page

### DIFF
--- a/lib/backbone.paginator.js
+++ b/lib/backbone.paginator.js
@@ -54,7 +54,7 @@
   var _clone = _.clone;
   var _each = _.each;
   var _pick = _.pick;
-  var _contains = _.includes;
+  var _contains = _.include;
   var _isEmpty = _.isEmpty;
   var _pairs = _.pairs || _.toPairs;
   var _invert = _.invert;


### PR DESCRIPTION
Using `_.include` instead of `_.includes` as the second one was not supported in Underscore.js 1.5.2 which is used in the example folder. Also, this fix addresses this issue: https://github.com/backbone-paginator/backbone.paginator/issues/386.